### PR TITLE
Move volume API calls to background thread and batch volume changes

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -15,7 +15,7 @@ on:
 env:
   # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: spotify-volume-controller-cpp.sln 
-  VCPKG_COMMIT: "16ee2ecb31788c336ace8bb14c21801efb6836e4"
+  VCPKG_COMMIT: "b02e341c927f16d991edbd915d8ea43eac52096c"
 
   # Configuration type to build.
   # You can convert this to a build matrix if you need coverage of multiple configuration types.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -66,6 +66,16 @@
       }
     },
     {
+      "name": "flags-windows-gcc-clang",
+      "description": "These flags are supported by both GCC and Clang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed",
+        "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed"
+      }
+    },
+    {
       "name": "flags-appleclang",
       "hidden": true,
       "cacheVariables": {
@@ -105,6 +115,19 @@
       "generator": "Visual Studio 17 2022",
       "architecture": "x64",
       "hidden": true
+    },
+    {
+      "name": "ci-win-mingw64",
+      "inherits": ["flags-windows-gcc-clang", "ci-std"],
+      "generator": "Ninja",
+      "hidden": true
+    },
+    {
+      "name": "vcpkg-mingw64-static",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-mingw-static"
+      }
     },
     {
       "name": "coverage-linux",

--- a/source/Client.h
+++ b/source/Client.h
@@ -2,8 +2,8 @@
 
 #include <map>
 
-#include <fmt/format.h>
 #include <cpr/cpr.h>
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 #include "Config.h"
@@ -20,7 +20,6 @@ public:
 
   [[nodiscard]] cpr::Response api_request(const std::string_view endpoint);
   [[nodiscard]] cpr::Response put_api_request(const std::string_view endpoint, const cpr::Payload& parameters);
-
 
   // Makes a request to the device endpoint
   [[nodiscard]] std::optional<json> get_devices();

--- a/source/Config.h
+++ b/source/Config.h
@@ -1,14 +1,15 @@
 #pragma once
+#include <chrono>
 #include <filesystem>
 
 #include <nlohmann/json.hpp>
 
 #include "data_types.h"
 
-// for convenience
-using json = nlohmann::json;
 namespace spotify_volume_controller
 {
+// for convenience
+using json = nlohmann::json;
 
 class Config
 {
@@ -24,6 +25,7 @@ public:
   keycode get_volume_up() const;
   keycode get_volume_down() const;
   volume volume_increment() const;
+  std::chrono::milliseconds batch_delay() const;
 
   bool is_default_down() const;
   bool is_default_up() const;

--- a/source/VolumeController.h
+++ b/source/VolumeController.h
@@ -1,13 +1,50 @@
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
 #include "Client.h"
 #include "Config.h"
 namespace spotify_volume_controller
 {
 
+class timer
+{
+public:
+
+  [[nodiscard]] bool is_running() const { return m_is_running; }
+  void start(const std::function<void(void)>& callback, std::chrono::milliseconds delay)
+  {
+    if (m_is_running) {
+      return;
+    }
+    m_is_running = true;
+    m_timer_thread = std::jthread
+    {
+      [callback, delay, this]()
+      {
+        std::this_thread::sleep_for(delay);
+        callback();
+        m_is_running = false;
+      }
+    };
+  }
+private:
+  std::jthread m_timer_thread;
+  bool m_is_running = false;
+};
+
 class VolumeController
 {
 public:
+  VolumeController(const VolumeController&) = delete;
+  VolumeController(VolumeController&&) = delete;
+  VolumeController& operator=(const VolumeController&) = delete;
+  VolumeController& operator=(VolumeController&&) = delete;
   VolumeController(const Config& config, Client& client);
   ~VolumeController();
 
@@ -23,13 +60,21 @@ public:
   void print_keys();
 
 private:
-  void set_volume(const volume to_volume);
+  void set_volume(volume to_volume);
+  void set_volume_loop();
+  void set_volume_to_desktop_device_volume();
   volume m_volume = 0;
   const Config m_config;
   Client m_client;
   const keycode m_volume_up_keycode;
   const keycode m_volume_down_keycode;
   std::optional<std::string> m_desktop_device_id = {};
+  std::thread m_client_thread;
+  std::jthread m_notify_timer_thread;
+  std::mutex m_volume_mutex;
+  std::condition_variable m_volume_cv;
+  std::queue<volume> m_volume_queue;
+  timer m_notify_timer{};
 };
 
 }  // namespace spotify_volume_controller

--- a/source/data_types.h
+++ b/source/data_types.h
@@ -8,6 +8,8 @@ namespace spotify_volume_controller
 using keycode = unsigned int;
 using volume_t = unsigned int;
 
+constexpr volume_t max_volume{100};
+
 struct volume
 {
   volume(volume_t v)
@@ -24,12 +26,12 @@ struct volume
 
   [[nodiscard]] volume_t operator+(const volume other) const
   {
-    return m_volume + other.m_volume > 100 ? 100 : m_volume + other.m_volume;
+    return m_volume + other.m_volume > max_volume ? max_volume : m_volume + other.m_volume;
   }
 
   volume& operator++()
   {
-    if (m_volume < 100) {
+    if (m_volume < max_volume) {
       m_volume++;
     }
     return *this;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,10 @@
       "name": "fmt",
       "version>=": "10.1.0"
     },
-
+    {
+      "name": "curl",
+      "version>=": "8.12.1"
+    },
     "cpr",
     "argparse",
     "nlohmann-json",


### PR DESCRIPTION
Blocking API calls on the main thread could cause key presses to not be registered by the application when done in quick succession, such as when a scroll wheel was used.

Batching volume increments done in quick succession (100ms by default) reduces the amount of API calls, avoiding throttling errors from Spotify. The batching delay is configured through a new config value, `batch_delay_ms`. Setting this to `0` disables the batching.