### PR TITLE
Update background volume polling logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source>"
 )
 
-target_compile_features(spotify_volume_controller_lib PUBLIC cxx_std_20)
+target_compile_features(spotify_volume_controller_lib PUBLIC cxx_std_23)
 target_compile_definitions(spotify_volume_controller_lib PRIVATE _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS=1)
 target_link_libraries(spotify_volume_controller_lib PRIVATE  nlohmann_json::nlohmann_json fmt::fmt cpr::cpr httplib::httplib)
 

--- a/source/Client.cpp
+++ b/source/Client.cpp
@@ -132,8 +132,11 @@ std::optional<volume> Client::get_current_playing_volume()
 
 void Client::print_error_message(const cpr::Response& response)
 {
-  std::cerr << "Error message: " << response.error.message << '\n';
-  std::cerr << "Reason: " << response.reason << '\n';
+  fmt::println(stderr, "Error when requesting {} [{}]", response.url.str(), response.status_code);
+  if (!response.error.message.empty()) {
+    fmt::println("Error message: {}", response.error.message);
+  }
+  fmt::println("Reason: {}", response.reason);
 }
 
 }  // namespace spotify_volume_controller

--- a/source/Config.h
+++ b/source/Config.h
@@ -33,7 +33,7 @@ public:
   keycode get_volume_down() const;
   volume volume_increment() const;
   std::chrono::milliseconds batch_delay() const;
-  std::chrono::milliseconds poll_rate() const;
+  std::chrono::milliseconds fetch_cooldown() const;
 
   bool is_default_down() const;
   bool is_default_up() const;

--- a/source/VolumeController.h
+++ b/source/VolumeController.h
@@ -77,7 +77,11 @@ private:
 
   std::mutex m_volume_mutex;
   std::condition_variable m_volume_cv;
-  std::queue<volume> m_volume_queue;
+  std::queue<volume_change> m_volume_queue;
+  std::condition_variable m_update_current_volume_cv;
+  std::mutex m_update_current_volume_mutex;
+  std::atomic<bool> m_updating_current_volume;
+  std::condition_variable m_updating_current_volume_cv;
   Timer m_notify_timer {};
 };
 

--- a/source/data_types.h
+++ b/source/data_types.h
@@ -14,6 +14,12 @@ using volume_t = unsigned int;
 
 constexpr volume_t max_volume {100};
 
+enum class volume_change : std::uint8_t
+{
+  increase,
+  decrease
+};
+
 struct volume
 {
   volume(const volume&) = default;
@@ -72,6 +78,17 @@ struct volume
     return old;
   }
 
+  volume& operator+=(const volume& other)
+  {
+    m_volume = (m_volume + other.m_volume > max_volume) ? max_volume : m_volume + other.m_volume;
+    return *this;
+  }
+
+  volume& operator-=(const volume& other)
+  {
+    m_volume = (m_volume < other.m_volume) ? 0 : m_volume - other.m_volume;
+    return *this;
+  }
   explicit operator volume_t() const { return m_volume; }
 };
 

--- a/source/key_hooks.cpp
+++ b/source/key_hooks.cpp
@@ -1,9 +1,9 @@
 #include <bit>
-#include <iostream>
 #include <utility>
 
 #include "key_hooks.h"
 
+#include <fmt/core.h>
 #include <libloaderapi.h>
 #include <minwindef.h>
 #include <windef.h>
@@ -44,7 +44,7 @@ LRESULT CALLBACK print_v_key(int n_code, WPARAM w_param, LPARAM l_param)
   }
   if (w_param == WM_KEYDOWN) {
     auto* keyboard_struct = std::bit_cast<KBDLLHOOKSTRUCT*>(l_param);
-    std::cout << keyboard_struct->vkCode << '\n';
+    fmt::println("{}", keyboard_struct->vkCode);
   }
   return CallNextHookEx(nullptr, n_code, w_param, l_param);
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,11 +1,12 @@
+#include <cstdio>
 #include <exception>
 #include <iostream>
 #include <optional>
 
 #include <argparse/argparse.hpp>
+#include <fmt/core.h>
 #define WIN32_LEAN_AND_MEAN  // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
-#include <wincon.h>
 
 #include "Client.h"
 #include "Config.h"
@@ -24,30 +25,30 @@ int main(int argc, char* argv[])
   try {
     program.parse_args(argc, argv);
   } catch (const std::exception& err) {
-    std::cerr << err.what() << '\n';
-    std::cerr << program;
+    fmt::println(stderr, "{}", err.what());
+    fmt::println(stderr, "{}", program.usage());
     return 1;
   }
 
-  std::cout << "Starting..." << '\n';
+  fmt::println("Starting...");
 
   spotify_volume_controller::Config const config = program.is_used("--config")
       ? spotify_volume_controller::Config(program.get("--config"))
       : spotify_volume_controller::Config();
   if (!config.is_valid()) {
-    std::cerr << "Failed to read config file." << '\n';
+    fmt::println(stderr, "Failed to read config file.");
     std::cin.get();
     return 1;
   }
   std::optional<spotify_volume_controller::token_t> token = spotify_volume_controller::oauth::get_token(config);
   if (!token.has_value()) {
-    std::cout << "Failed to connect to spotify, exiting..." << '\n';
+    fmt::println(stderr, "Failed to connect to Spotify, exiting...");
     std::cin.get();
     return 1;
   }
   spotify_volume_controller::Client client(token.value(), config);
 
-  std::cout << "Connected to spotify successfully!" << '\n';
+  fmt::println("Connected to spotify successfully!");
   if (config.hide_window()) {
     FreeConsole();
   }


### PR DESCRIPTION
Change from periodically polling the volume in the background to instead fetch the current volume the user changes the volume. The frequency of the fetching is configured via the "fetch_cooldown" setting (default 2 seconds)